### PR TITLE
Fix import of hostmaster item in SOA record

### DIFF
--- a/import-zone
+++ b/import-zone
@@ -125,8 +125,8 @@ unless ($pzoneid > 0) {
 
   @soa = split(/\s+/,$rec->{SOA});
   $zonehash{hostmaster}=$soa[1];
-  $zonehash{hostmaster} =~ s/\./@/;
-  $zonehash{hostmaster} =~ s/\.$//;
+#  $zonehash{hostmaster} =~ s/\./@/;
+#  $zonehash{hostmaster} =~ s/\.$//;
   $zonehash{serial}=$soa[2];
   $zonehash{refresh}=$soa[3];
   $zonehash{retry}=$soa[4];


### PR DESCRIPTION
The import was correcting the email address (changing the first dot to an alias and removing the last dot). But in the zone edit entry, only domain format is enabled, not email format. An alternative fix would be to change it to 'email' type, but that would require some SQL update command when migrating to the new version. Additionally, it is common knowledge that email in an SOA record is written in domain format.